### PR TITLE
🩹Selectively pull from splitrb/split to defer major version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ rvm:
   - 2.5.7
   - 2.6.5
 
+services:
+  - redis-server
+
 gemfile:
   - gemfiles/4.2.gemfile
   - gemfiles/5.0.gemfile

--- a/lib/split.rb
+++ b/lib/split.rb
@@ -35,9 +35,9 @@ module Split
   #      `Redis::DistRedis`, or `Redis::Namespace`.
   def redis=(server)
     @redis = if server.is_a?(String)
-      Redis.new(:url => server, :thread_safe => true)
+      Redis.new(url: server)
     elsif server.is_a?(Hash)
-      Redis.new(server.merge(:thread_safe => true))
+      Redis.new(server)
     elsif server.respond_to?(:smembers)
       server
     else

--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -165,7 +165,7 @@ module Split
     end
 
     def reset
-      Split.redis.hmset key, 'participant_count', 0, 'completed_count', 0, 'recorded_info', ''
+      Split.redis.hmset key, 'participant_count', 0, 'completed_count', 0, 'recorded_info', nil.to_s
       unless goals.empty?
         goals.each do |g|
           field = "completed_count:#{g}"

--- a/lib/split/alternative.rb
+++ b/lib/split/alternative.rb
@@ -165,7 +165,7 @@ module Split
     end
 
     def reset
-      Split.redis.hmset key, 'participant_count', 0, 'completed_count', 0, 'recorded_info', nil
+      Split.redis.hmset key, 'participant_count', 0, 'completed_count', 0, 'recorded_info', ''
       unless goals.empty?
         goals.each do |g|
           field = "completed_count:#{g}"

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -101,7 +101,7 @@ module Split
     end
 
     def new_record?
-      !redis.exists(name)
+      !redis.exists?(name)
     end
 
     def ==(obj)

--- a/lib/split/experiment.rb
+++ b/lib/split/experiment.rb
@@ -87,7 +87,7 @@ module Split
         persist_experiment_configuration
       end
 
-      redis.hset(experiment_config_key, :resettable, resettable)
+      redis.hset(experiment_config_key, :resettable, resettable.to_s)
       redis.hset(experiment_config_key, :algorithm, algorithm.to_s)
       self
     end
@@ -390,11 +390,28 @@ module Split
 
     def jstring(goal = nil)
       js_id = if goal.nil?
-                name
-              else
-                name + "-" + goal
-              end
-      js_id.gsub('/', '--')
+        name
+      else
+        name + "-" + goal
+      end
+      js_id.gsub("/", "--")
+    end
+
+    def cohorting_disabled?
+      @cohorting_disabled ||= begin
+        value = redis.hget(experiment_config_key, :cohorting)
+        value.nil? ? false : value.downcase == "true"
+      end
+    end
+
+    def disable_cohorting
+      @cohorting_disabled = true
+      redis.hset(experiment_config_key, :cohorting, true.to_s)
+    end
+
+    def enable_cohorting
+      @cohorting_disabled = false
+      redis.hset(experiment_config_key, :cohorting, false.to_s)
     end
 
     protected

--- a/lib/split/experiment_catalog.rb
+++ b/lib/split/experiment_catalog.rb
@@ -13,7 +13,7 @@ module Split
     end
 
     def self.find(name)
-      return unless Split.redis.exists(name)
+      return unless Split.redis.exists?(name)
       Experiment.new(name).tap { |exp| exp.load_from_redis }
     end
 

--- a/lib/split/user.rb
+++ b/lib/split/user.rb
@@ -27,7 +27,8 @@ module Split
     def max_experiments_reached?(experiment_key)
       if Split.configuration.allow_multiple_experiments == 'control'
         experiments = active_experiments
-        count_control = experiments.count {|k,v| k == experiment_key || v == 'control'}
+        experiment_key_without_version = key_without_version(experiment_key)
+        count_control = experiments.count {|k,v| k == experiment_key_without_version || v == 'control'}
         experiments.size > count_control
       else
         !Split.configuration.allow_multiple_experiments &&

--- a/spec/alternative_spec.rb
+++ b/spec/alternative_spec.rb
@@ -126,7 +126,7 @@ describe Split::Alternative do
 
   it "should save to redis" do
     alternative.save
-    expect(Split.redis.exists('basket_text:Basket')).to be true
+    expect(Split.redis.exists?('basket_text:Basket')).to be true
   end
 
   it "should increment participation count" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -240,6 +240,7 @@ describe Split::Configuration do
       it "should use the ENV variable" do
         ENV['REDIS_URL'] = "env_redis_url"
         expect(Split::Configuration.new.redis).to eq("env_redis_url")
+        ENV.delete('REDIS_URL')
       end
     end
   end

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -67,7 +67,7 @@ describe Split::Experiment do
       experiment_start_time = Time.parse("Sat Mar 03 14:01:03")
       expect(Time).to receive(:now).twice.and_return(experiment_start_time)
       experiment.save
-      Split.redis.hset(:experiment_start_times, experiment.name, experiment_start_time)
+      Split.redis.hset(:experiment_start_times, experiment.name, experiment_start_time.to_s)
 
       expect(Split::ExperimentCatalog.find('basket_text').start_time).to eq(experiment_start_time)
     end

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -37,7 +37,7 @@ describe Split::Experiment do
 
     it "should save to redis" do
       experiment.save
-      expect(Split.redis.exists('basket_text')).to be true
+      expect(Split.redis.exists?('basket_text')).to be true
     end
 
     it "should save the start time to redis" do
@@ -85,7 +85,7 @@ describe Split::Experiment do
     it "should not create duplicates when saving multiple times" do
       experiment.save
       experiment.save
-      expect(Split.redis.exists('basket_text')).to be true
+      expect(Split.redis.exists?('basket_text')).to be true
       expect(Split.redis.lrange('basket_text', 0, -1)).to eq(['{"Basket":1}', '{"Cart":1}'])
     end
 
@@ -180,7 +180,7 @@ describe Split::Experiment do
       experiment.save
 
       experiment.delete
-      expect(Split.redis.exists('link_color')).to be false
+      expect(Split.redis.exists?('link_color')).to be false
       expect(Split::ExperimentCatalog.find('link_color')).to be_nil
     end
 

--- a/spec/goals_collection_spec.rb
+++ b/spec/goals_collection_spec.rb
@@ -48,7 +48,7 @@ describe Split::GoalsCollection do
       goals_collection.save
 
       goals_collection.delete
-      expect(Split.redis.exists(goals_key)).to be false
+      expect(Split.redis.exists?(goals_key)).to be false
     end
   end
 

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -229,18 +229,30 @@ describe Split::Helper do
 
       context "when user already has experiment" do
         let(:mock_user){ Split::User.new(self, {'test_0' => 'test-alt'}) }
-        before{
+
+        before do
           Split.configure do |config|
             config.allow_multiple_experiments = 'control'
           end
+
           Split::ExperimentCatalog.find_or_initialize('test_0', 'control', 'test-alt').save
           Split::ExperimentCatalog.find_or_initialize('test_1', 'control', 'test-alt').save
-        }
+        end
 
         it "should restore previously selected alternative" do
           expect(ab_user.active_experiments.size).to eq 1
           expect(ab_test(:test_0, {'control' => 100}, {"test-alt" => 1})).to eq 'test-alt'
           expect(ab_test(:test_0, {'control' => 1}, {"test-alt" => 100})).to eq 'test-alt'
+        end
+
+        it "should select the correct alternatives after experiment resets" do
+          experiment = Split::ExperimentCatalog.find(:test_0)
+          experiment.reset
+          mock_user[experiment.key] = 'test-alt'
+
+          expect(ab_user.active_experiments.size).to eq 1
+          expect(ab_test(:test_0, {'control' => 100}, {"test-alt" => 1})).to eq 'test-alt'
+          expect(ab_test(:test_0, {'control' => 0}, {"test-alt" => 100})).to eq 'test-alt'
         end
 
         it "lets override existing choice" do

--- a/spec/persistence/cookie_adapter_spec.rb
+++ b/spec/persistence/cookie_adapter_spec.rb
@@ -52,7 +52,7 @@ describe Split::Persistence::CookieAdapter do
     it "puts multiple experiments in a single cookie" do
       subject["foo"] = "FOO"
       subject["bar"] = "BAR"
-      expect(context.response.headers["Set-Cookie"]).to match(/\Asplit=%7B%22foo%22%3A%22FOO%22%2C%22bar%22%3A%22BAR%22%7D; path=\/; expires=[a-zA-Z]{3}, \d{2} [a-zA-Z]{3} \d{4} \d{2}:\d{2}:\d{2} -0000\Z/)
+      expect(context.response.headers["Set-Cookie"]).to match(/\Asplit=%7B%22foo%22%3A%22FOO%22%2C%22bar%22%3A%22BAR%22%7D; path=\/; expires=[a-zA-Z]{3}, \d{2} [a-zA-Z]{3} \d{4} \d{2}:\d{2}:\d{2} [A-Z]{3}\Z/)
     end
 
     it "ensure other added cookies are not overriden" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,17 +13,15 @@ require 'yaml'
 
 Dir['./spec/support/*.rb'].each { |f| require f }
 
-require "fakeredis"
-
-G_fakeredis = Redis.new
-
 module GlobalSharedContext
   extend RSpec::SharedContext
   let(:mock_user){ Split::User.new(double(session: {})) }
+
   before(:each) do
     Split.configuration = Split::Configuration.new
-    Split.redis = G_fakeredis
-    Split.redis.flushall
+    Split.redis = Redis.new
+    Split.redis.select(10)
+    Split.redis.flushdb
     @ab_user = mock_user
     params = nil
   end

--- a/split.gemspec
+++ b/split.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'redis',           '>= 2.1'
+  s.add_dependency 'redis',           '>= 4.2'
   s.add_dependency 'sinatra',         '>= 1.2.6'
   s.add_dependency 'simple-random',   '>= 0.9.3'
 

--- a/split.gemspec
+++ b/split.gemspec
@@ -39,6 +39,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',        '~> 12'
   s.add_development_dependency 'rspec',       '~> 3.7'
   s.add_development_dependency 'pry',         '~> 0.10'
-  s.add_development_dependency 'fakeredis',   '~> 0.7'
   s.add_development_dependency 'rails',       '>= 4.2'
 end


### PR DESCRIPTION
## Why?

`Split::Experiment#new_record?` always returns false because `!0` and `!1` are equivalent, and our version of redis `Redis#exists` returns an integer. For the version of redis split `v3.4.1` targeted, that might have returned a boolean.

## What?

Commits from `splitrb/split` `main` branch until the build passes and `split` uses `Redis#exists?`